### PR TITLE
Initial commit of get metrics

### DIFF
--- a/src/main/scala/datadog/DataDogClient.scala
+++ b/src/main/scala/datadog/DataDogClient.scala
@@ -25,6 +25,7 @@ case class DataDogClient(applicationName: String,
 
   private val sendEventURL: URL = URL.parse(s"https://api.$region.datadoghq.com/api/v1/events")
   private val sendLogsURL: URL = URL.parse(s"https://http-intake.logs.$region.datadoghq.com/api/v2/logs")
+  private val getMetricsURL: URL = URL.parse(s"https://api.$region.datadoghq.com/api/v2/metrics")
 
   def event(event: DataDogEvent): IO[Unit] = client
     .url(sendEventURL)
@@ -70,6 +71,14 @@ case class DataDogClient(applicationName: String,
   }
   def createLogHandler()(implicit runtime: IORuntime): LogHandler = (record: LogRecord) =>
     ddClient.log(record).unsafeRunAndForget()
+
+  def getMetrics(dataDogMetricRequest: DataDogMetricRequest): IO[Json] = {
+    val metricsURL: URL = dataDogMetricRequest.appendQueryParams(getMetricsURL)
+
+    client
+      .url(metricsURL)
+      .call[Json]
+  }
 }
 
 object DataDogClient {

--- a/src/main/scala/datadog/DataDogMetricRequest.scala
+++ b/src/main/scala/datadog/DataDogMetricRequest.scala
@@ -1,0 +1,42 @@
+package datadog
+
+import fabric.rw.RW
+import spice.net.URL
+
+import scala.concurrent.duration.FiniteDuration
+
+case class DataDogMetricRequest(metricType: Option[String],
+                                includePercentiles: Option[Boolean],
+                                window: Option[FiniteDuration],
+                                tags: Option[String],
+                        ) {
+
+  def appendQueryParams(url: URL) : URL = {
+    metricType match {
+      case Some(t) =>
+        url.withParam("filter[metric_type]", t, true)
+    }
+
+    includePercentiles match {
+      case Some(p) =>
+        url.withParam("filter[include_percentiles]", p.toString, true)
+    }
+
+    tags match {
+      case Some(t) =>
+        url.withParam("filter[include_percentiles]", t, true)
+        url.withParam("filter[query]", "true", true)
+    }
+
+    window match {
+      case Some(w) =>
+        url.withParam("window[seconds]", w.toString(), true)
+    }
+
+    url
+  }
+}
+
+
+
+object DataDogMetricRequest {}


### PR DESCRIPTION
The append query metrics does feel like an anti pattern but at first i was appending a string since i didn't know what the `URL` object had interms of query params. 

Can change to a util and implement a `filter` trait since it will probably be needed for more than 1 call 